### PR TITLE
feat(schema.json): Adiciona novos campos de subeventos e oficionas re…

### DIFF
--- a/src/api/event/content-types/event/schema.json
+++ b/src/api/event/content-types/event/schema.json
@@ -59,7 +59,7 @@
       "target": "api::partner.partner",
       "inversedBy": "events"
     },
-    "data": {
+    "data_inicio": {
       "required": true,
       "type": "date"
     },
@@ -73,6 +73,20 @@
     },
     "destaque": {
       "type": "boolean"
+    },
+    "subeventos": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::event.event"
+    },
+    "data_fim": {
+      "required": true,
+      "type": "date"
+    },
+    "oficinas": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::workshop.workshop"
     }
   }
 }


### PR DESCRIPTION
#14 - [E3] CMS: Suporte a cadastro de atividades em eventos
====
  
### 🆙 CHANGELOG

- Criação de relacionamento entre evento e subeventos. (Um evento possui * subeventos)
- Criação de relacionamento entre evento e oficinas. (Um evento possui * oficinas)
- Renomeação do campo data para data_inicio
- Adição do campo data_fim

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Solicitei **code review** para 2 pessoas

## ⚠️ Como testar:

- [x] Acesse a branch 14/Suporte-a-cadastro-de-atividades-em-eventos
- [x] Acessar o CMS utilizando o comando 'yarn develop'
- [x] Entre no Strapi CMS (http://localhost:1337/admin) e cadastre eventos com todas as informações pedidas.
- [x] Tente cadastrar um ou mais subeventos
- [x] Tente cadastrar uma ou mais oficinas
- [ ] Teste o retorno no postman com a url abaixo
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada.

http://localhost:1337/api/events/?populate=parceires&populate=subeventos&populate=fotos_evento&populate=oficinas
 