### PR TITLE
remove campos de descricao do sobre nos

### DIFF
--- a/src/api/sobre-nos/content-types/sobre-nos/schema.json
+++ b/src/api/sobre-nos/content-types/sobre-nos/schema.json
@@ -16,66 +16,6 @@
     }
   },
   "attributes": {
-    "descricao1": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "richtext",
-      "default": "## Titulo ",
-      "required": true
-    },
-    "descricao2": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "richtext",
-      "default": "## Titulo    ",
-      "required": true
-    },
-    "descricao3": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "richtext",
-      "default": "## Titulo ",
-      "required": true
-    },
-    "descricao4": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "richtext",
-      "default": "## Titulo ",
-      "required": true
-    },
-    "descricao5": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "richtext",
-      "default": "## Titulo ",
-      "required": true
-    },
-    "descricao6": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "richtext",
-      "default": "## Titulo ",
-      "required": true
-    },
     "foto": {
       "type": "media",
       "multiple": false,
@@ -88,6 +28,16 @@
           "localized": true
         }
       }
+    },
+    "descricao": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "richtext",
+      "default": "## Titulo ",
+      "required": true
     }
   }
 }


### PR DESCRIPTION
#17 / Remove Campos descricao da pagina sobre nos
  
### 🆙 CHANGELOG

- remove campos de descrição deixando só um, para que o cliente use Markdown para usar o campo do jeito que desejar.

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [ ] Acessar a branch Ajustes no repositorio nossa-casa-cms
- [ ] No terminar digitar o comando "yarn develop" e acessar a URL disponivel a seguir
- [ ] Em content menager va na coluna sobre nós 
- [ ] Veja se há coerência com os campos.
