### PR TITLE
Feat: Muda Campo Sobre Nós para Tipo singular - @joyce-caroline @ange…

### DIFF
--- a/src/api/sobre-nos/content-types/sobre-nos/schema.json
+++ b/src/api/sobre-nos/content-types/sobre-nos/schema.json
@@ -1,5 +1,5 @@
 {
-  "kind": "collectionType",
+  "kind": "singleType",
   "collectionName": "plural_sobre_nos",
   "info": {
     "singularName": "sobre-nos",


### PR DESCRIPTION
# 27 - sobre-nos-singular

🆙 CHANGELOG

O campo Sobre Nós no Strapi deve estar no Tipo Singular, assim como a Galeria.

⚠️ Me certifico que:

 - [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
 - [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
 - [ ] Solicitei code review para 2 pessoas
 - [ ] Solicitei QA para 2 pessoas
 - [ ] Obtive aprovação de QA e posso fazer merge

⚠️ Como testar:

 - [ ] Acesse a branch 27/sobre-nos-singular
 - [ ] Abra o Strapi e acesse o Gerenciador de Conteúdo
 - [ ] Verificar que o campo Sobre Nós está como tipo singular.

